### PR TITLE
Batch Players component updates

### DIFF
--- a/client_new/scripts/components/Players.js
+++ b/client_new/scripts/components/Players.js
@@ -55,12 +55,24 @@ define([
             });
         },
 
+        _animRequest: null,
         _onChange: function() {
-            if(this.isMounted())
-                this.setState(getState());
+            // Already scheduled an update.
+            if (this._animRequest) return;
+
+            // Schedule a new update of this component.
+            var self = this;
+            this._animRequest =
+            window.requestAnimationFrame(function() {
+                if(self.isMounted())
+                    self.forceUpdate();
+            });
         },
 
         render: function() {
+            // Reset the animation request id when rendering.
+            this._animRequest = null;
+
             var self = this;
 
             var usersWonCashed = [];


### PR DESCRIPTION
This patch batches updates of the player list component to the next animation frame. Improves performance when lots of updates happen almost simultaneously, i.e. when players are auto-joining a new game or auto-cashing out at the same time.

I'm not too sure what the correct way is to implement this. So any feedback is welcome.

Before | After
-----------|------------
<img src=https://cloud.githubusercontent.com/assets/8939884/11664875/676e44c2-9de4-11e5-9f19-2b4d0cac1b80.png height="342px"> | <img src=https://cloud.githubusercontent.com/assets/8939884/11664880/6ed69d9a-9de4-11e5-9eb1-9148f2f5a141.png height="342px">
